### PR TITLE
Implemented `FilterCommand`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 * `Exception`s
   * [`CouldNotProcessData` template](#exceptioncouldnotprocessdata-template)
   * [`NotImplemented`](#exceptionnotimplemented)
+* [`FilterCommand`](#filtercommand)
 * [`HasRequirements` trait](#hasrequirements-trait)
 
 ## [`Exception\CouldNotProcessData` template](./src/Exception/CouldNotProcessData.php)
@@ -36,6 +37,16 @@ final class StringablePrototype implements \Stringable {
         Exception\NotImplemented::throw(__METHOD__);
     }
 }
+```
+
+## [`FilterCommand`](./src/FilterCommand.php)
+
+Object used to filter input using an external command.
+
+```php
+namespace PetrKnap\Shorts;
+
+echo (new FilterCommand('tr', ['a-z', 'A-Z']))->filter('input');  # echo "input" | tr a-z A-Z
 ```
 
 ## [`HasRequirements` trait](./src/HasRequirements.php)

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "sort-packages": true
   },
   "conflict": {
-    "phpunit/phpunit": "<9|>=12"
+    "phpunit/phpunit": "<9|>=12",
+    "symfony/process": "<4|>=8"
   },
   "description": "Set of short PHP helpers",
   "funding": [
@@ -29,7 +30,10 @@
     "array",
     "helper",
     "markdown",
-    "phpunit"
+    "phpunit",
+    "filter",
+    "filter-command",
+    "external-filter"
   ],
   "license": "LGPL-3.0-or-later",
   "name": "petrknap/shorts",
@@ -38,6 +42,7 @@
   },
   "require-dev": {
     "ext-zlib": "*",
+    "symfony/process": "*",
     "nunomaduro/phpinsights": "^2.11",
     "phpstan/phpstan": "^1.12",
     "squizlabs/php_codesniffer": "^3.7",
@@ -65,6 +70,7 @@
     ]
   },
   "suggest": {
-    "phpunit/phpunit": "Required by PHP Unit helpers"
+    "phpunit/phpunit": "Required by PHP Unit helpers",
+    "symfony/process": "Required by by etxernal process helpers"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
       "phpcs --colors --standard=PSR12 --exclude=Generic.Files.LineLength src tests",
       "phpstan analyse --level max src --ansi --no-interaction",
       "phpstan analyse --level 5 tests --ansi --no-interaction",
-      "phpinsights analyse src --ansi --no-interaction --format=github-action | sed -e \"s#::error file=$PWD/#::notice file=#g\""
+      "phpinsights analyse src tests --ansi --no-interaction --format=github-action | sed -e \"s#::error file=$PWD/#::notice file=#g\""
     ],
     "check-requirements": [
       "composer update \"petrknap/*\"",

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -7,7 +7,7 @@ namespace PetrKnap\Shorts\Exception;
 use Throwable;
 
 /**
- * @internal domain exception
+ * @internal root exception
  */
 interface Exception extends Throwable
 {

--- a/src/Exception/FilterCommandCouldNotFilterData.php
+++ b/src/Exception/FilterCommandCouldNotFilterData.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\Shorts\Exception;
+
+/**
+ * @extends CouldNotProcessData<string>
+ */
+final class FilterCommandCouldNotFilterData extends CouldNotProcessData implements FilterCommandException
+{
+}

--- a/src/Exception/FilterCommandException.php
+++ b/src/Exception/FilterCommandException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\Shorts\Exception;
+
+interface FilterCommandException extends Exception
+{
+}

--- a/src/FilterCommand.php
+++ b/src/FilterCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\Shorts;
+
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+final class FilterCommand
+{
+    use HasRequirements;
+
+    /**
+     * @param non-empty-string $command
+     * @param array<non-empty-string> $options
+     */
+    public function __construct(
+        private readonly string $command,
+        private readonly array $options = [],
+    ) {
+        self::checkRequirements(
+            classes: [
+                Process::class,
+                ProcessFailedException::class,
+            ],
+        );
+    }
+
+    /**
+     * @throws Exception\FilterCommandCouldNotFilterData
+     */
+    public function filter(string $data): string
+    {
+        $process = new Process([
+            $this->command,
+            ...$this->options,
+        ]);
+        $process->setInput($data);
+        $process->run();
+        if (!$process->isSuccessful()) {
+            throw new Exception\FilterCommandCouldNotFilterData(__METHOD__, $data, new ProcessFailedException($process));
+        }
+        return $process->getOutput();
+    }
+}

--- a/src/PhpUnit/Exception/Exception.php
+++ b/src/PhpUnit/Exception/Exception.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace PetrKnap\Shorts\PhpUnit\Exception;
 
-use PetrKnap\Shorts\Exception\Exception as Base;
+use PetrKnap\Shorts\Exception\Exception as ParentException;
 
 /**
- * @internal domain exception
+ * @internal root exception
  */
-interface Exception extends Base
+interface Exception extends ParentException
 {
 }

--- a/tests/FilterCommandTest.php
+++ b/tests/FilterCommandTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\Shorts;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class FilterCommandTest extends TestCase
+{
+    private const INPUT = 'input';
+
+    public function testFiltersInputByCommand(): void
+    {
+        self::assertSame(
+            self::INPUT,
+            (new FilterCommand('cat'))->filter(self::INPUT),
+        );
+    }
+
+    #[DataProvider('dataThrows')]
+    public function testThrows(string $command, array $options, string $data): void
+    {
+        self::expectException(Exception\FilterCommandCouldNotFilterData::class);
+
+        (new FilterCommand($command, $options))->filter($data);
+    }
+
+    public static function dataThrows(): array
+    {
+        return [
+            'unknown command' => ['unknown', [], ''],
+            'unknown option' => ['php', ['--unknown'], ''],
+            'wrong data' => ['php', [], '<?php wrong data'],
+        ];
+    }
+}

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -20,6 +20,7 @@ final class ReadmeTest extends TestCase implements PhpUnit\MarkdownFileTestInter
         return [
             'exceptioncouldnotprocessdata-template' => '',
             'exceptionnotimplemented' => '',
+            'filtercommand' => 'INPUT',
             'hasrequirements-trait' => '',
         ];
     }


### PR DESCRIPTION
- [x] This pull request does not contain any breaking change.
- [ ] I asked [the AI](https://copilot.microsoft.com/) to briefly summarize, use and improve the feature(s), and I'm okay with the output:
<!-- ⇅ remove it if it doesn't make sense ⇅ -->
<!-- ↓ here belongs the AI inputs (>>) and outputs (>) ↓ -->
>> Could you briefly summarize the following code for me?
>> ```php
>> final class FilterCommand
>> {
>>     /**
>>      * @param non-empty-string $command
>>      * @param array<non-empty-string> $options
>>      */
>>     public function __construct(
>>         private readonly string $command,
>>         private readonly array $options = [],
>>     ) {/* ... */}
>> 
>>     /**
>>      * @throws Exception\FilterCommandCouldNotFilterData
>>      */
>>     public function filter(string $data): string {/* ... */}
>> }
>> ```
>
> Sure! Here's a brief summary of the code:
>
> The code defines a `final` class named `FilterCommand`. This class includes:
> 1. **Constructor**:
>    - Takes two parameters: a non-empty string `$command` and an array of non-empty strings `$options` (with an empty array as the default value).
>    - Initializes two private, readonly properties: `$command` and `$options`.
> 2. **Method**:
>    - A method named `filter` that takes a string `$data` as a parameter and returns a `string`.
>    - This method may throw an exception of type `Exception\FilterCommandCouldNotFilterData` if the filtering operation fails.
>
> In summary, `FilterCommand` is designed to perform a filtering operation using the specified command and options, while ensuring any issues during the operation are handled through exceptions.
>
>> Could you show me how to use it?
>
> Absolutely! Here's an example of how you can use the `FilterCommand` class to filter data using a specified command and options in a PHP script:
> ```php
> try {
>     // Create a new FilterCommand object with the desired command and options
>     $filterCommand = new FilterCommand('grep', ['pattern']);
> 
>     // Define the input data to be filtered
>     $inputData = "This is a line of input data.\nAnother line with pattern.\nMore data here.";
> 
>     // Apply the filter to the input data
>     $outputData = $filterCommand->filter($inputData);
> 
>     // Print the filtered output
>     echo "Filtered output: $outputData\n";
> } catch (Exception\FilterCommandCouldNotFilterData $e) {
>     // Handle any exceptions that occur during filtering
>     echo 'Error: ' . $e->getMessage();
> }
> ```
>
>> Is there any way to name something better?
>
> Let's fine-tune the naming for better clarity and readability:
> 1. **Class Name**: The class name `FilterCommand` is quite descriptive, but if you want to emphasize its function, consider something like `CommandFilter`.
> 2. **Property Names**:
>    - `$command` is straightforward, but if you want to be more explicit, you could use `$filterCommand`.
>    - `$options` is also clear, but `commandOptions` could be more descriptive.
> 3. **Method Name**: `filter` is quite apt. If you prefer something more descriptive, you could use `applyFilter` or `executeFilter`.
> 4. **Exception Name**: `FilterCommandCouldNotFilterData` is quite long and specific. A shorter, equally descriptive name could be `FilterFailedException`.
>
>> Is better argument name `$data` or `$input` for method `FilterCommand::filter()`?
> 
> Choosing between `$data` and `$input` depends on the context and what the method is doing with the argument. Here are some considerations for each:
>
> **Using `$data`**:
> - **Descriptive**: If the method is processing or manipulating the content, calling it `$data` can make it clear that it's dealing with a piece of information.
> - **Clarity**: It indicates that the argument is expected to be some form of data that will undergo transformation or filtering.
> **Using `$input`**:
> - **General*: If the method is expected to take various forms of input (e.g., text, numbers, streams), `$input` can be more flexible and general.
> - **Indicates Source**: It suggests that the argument is something being received to be processed, highlighting the method's role in handling incoming data.
>
> In the context of the filter method, where the method likely processes and transforms the input data, both `$data` and `$input` could be appropriate. However, if you want to emphasize that the method is processing raw information that will be filtered, `$data` might be slightly more descriptive.
> 
> In conclusion, both `$data` and `$input` are valid choices. If your method is more about transforming or processing the content, `$data` might be preferable. If it's about handling a variety of inputs, `$input` could be the better choice.
