### PR TITLE
Created `IlluminateDatabase` testing helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
   * [`CouldNotProcessData` template](#couldnotprocessdata-template)
   * [`NotImplemented`](#notimplemented)
 * [`HasRequirements` trait](#hasrequirements-trait)
-* [PHPUnit](#phpunit)
+* [Testing](#testing)
+  * [`IlluminateDatabase` helper](#illuminatedatabase-helper)
   * [`MarkdownFileTest` interface + trait](#markdownfiletest-interface--trait)
 
 
@@ -66,7 +67,26 @@ but it could improve them and check [`suggest`s](https://getcomposer.org/doc/04-
 
 
 
-## PHPUnit
+## Testing
+
+
+### [`IlluminateDatabase` helper](./src/Testing/IlluminateDatabase.php)
+
+Simple helper which provides logic to test `Illuminate\Database` without `Laravel` mess.
+
+```php
+$pdo = new PDO('sqlite::memory:');
+$pdo->exec('CREATE TABLE tigers (id INTEGER PRIMARY KEY, name VARCHAR)');
+$pdo->prepare('INSERT INTO tigers (name) VALUES (?), (?), (?)')
+    ->execute(['Roque', 'Jasper', 'Gopal']);
+
+PetrKnap\Shorts\Testing\IlluminateDatabase::createCapsuleManager($pdo)
+    ->bootEloquent();
+
+class Tiger extends Illuminate\Database\Eloquent\Model {}
+
+assert(Tiger::count() === 3);
+```
 
 
 ### [`MarkdownFileTest` interface](./src/PhpUnit/MarkdownFileTestInterface.php) + [trait](./src/PhpUnit/MarkdownFileTestTrait.php)

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "sort-packages": true
   },
   "conflict": {
+    "illuminate/database": "<10.49|>=13",
     "phpunit/phpunit": "<10.5|>=13"
   },
   "description": "Set of short PHP helpers",
@@ -37,6 +38,7 @@
   },
   "require-dev": {
     "ext-zlib": "*",
+    "illuminate/database": "*",
     "nunomaduro/phpinsights": "^2.11",
     "phpstan/phpstan": "^1.12",
     "squizlabs/php_codesniffer": "^3.7",
@@ -64,6 +66,7 @@
     ]
   },
   "suggest": {
+    "illuminate/database": "Required by IlluminateDatabase testing helper",
     "phpunit/phpunit": "Required by PHP Unit helpers"
   }
 }

--- a/src/PhpUnit/Exception/Exception.php
+++ b/src/PhpUnit/Exception/Exception.php
@@ -7,6 +7,8 @@ namespace PetrKnap\Shorts\PhpUnit\Exception;
 use PetrKnap\Shorts\Exception\Exception as Base;
 
 /**
+ * @todo BC move it to Testing
+ *
  * @internal domain exception
  */
 interface Exception extends Base

--- a/src/PhpUnit/Exception/MarkdownFileTestException.php
+++ b/src/PhpUnit/Exception/MarkdownFileTestException.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace PetrKnap\Shorts\PhpUnit\Exception;
 
+/**
+ * @todo BC move it to Testing
+ */
 interface MarkdownFileTestException extends Exception
 {
 }

--- a/src/PhpUnit/Exception/MarkdownFileTestTraitCannotDetermineExpectedOutput.php
+++ b/src/PhpUnit/Exception/MarkdownFileTestTraitCannotDetermineExpectedOutput.php
@@ -8,6 +8,8 @@ use OutOfRangeException;
 use PetrKnap\Shorts\PhpUnit\MarkdownFileTestTrait;
 
 /**
+ * @todo BC move it to Testing
+ *
  * @internal used by {@see MarkdownFileTestTrait}
  */
 final class MarkdownFileTestTraitCannotDetermineExpectedOutput extends OutOfRangeException implements MarkdownFileTestException

--- a/src/PhpUnit/Exception/MarkdownFileTestTraitDidNotUseAllExpectedOutputs.php
+++ b/src/PhpUnit/Exception/MarkdownFileTestTraitDidNotUseAllExpectedOutputs.php
@@ -8,6 +8,8 @@ use OutOfRangeException;
 use PetrKnap\Shorts\PhpUnit\MarkdownFileTestTrait;
 
 /**
+ * @todo BC move it to Testing
+ *
  * @internal used by {@see MarkdownFileTestTrait}
  */
 final class MarkdownFileTestTraitDidNotUseAllExpectedOutputs extends OutOfRangeException implements MarkdownFileTestException

--- a/src/PhpUnit/MarkdownFileTestInterface.php
+++ b/src/PhpUnit/MarkdownFileTestInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace PetrKnap\Shorts\PhpUnit;
 
+/**
+ * @todo BC move it to Testing
+ */
 interface MarkdownFileTestInterface
 {
     /**

--- a/src/PhpUnit/MarkdownFileTestTrait.php
+++ b/src/PhpUnit/MarkdownFileTestTrait.php
@@ -10,6 +10,8 @@ use PHPUnit\Framework\TestCase;
 use Traversable;
 
 /**
+ * @todo BC move it to Testing
+ *
  * @psalm-require-implements MarkdownFileTestInterface
  * @psalm-require-extends TestCase
  *

--- a/src/Testing/IlluminateDatabase.php
+++ b/src/Testing/IlluminateDatabase.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\Shorts\Testing;
+
+use Illuminate\Database\Capsule\Manager;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Eloquent\Model;
+use PDO;
+use PetrKnap\Shorts\HasRequirements;
+
+final class IlluminateDatabase
+{
+    use HasRequirements;
+
+    /**
+     * @see Manager::addConnection() default value of $name
+     */
+    public const CONNECTION_DEFAULT_NAME = 'default';
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * @todo add support for PDO|array<string, string|PDO>|array<string, PDO|array<string, string|PDO>> $connections, PDO instance at self::CONNECTION_PDO_KEY
+     *
+     * @param PDO|array<string, PDO> $connections well-known PDOs keyed by names
+     *
+     * @return Manager
+     *
+     * @see Manager::setAsGlobal() if you want to use {@see Manager} globally
+     * @see Manager::bootEloquent() if you want to use {@see Model}s
+     */
+    public static function createCapsuleManager(PDO|array $connections): object
+    {
+        self::checkRequirements(
+            classes: [
+                Manager::class,
+                Connection::class,
+            ],
+        );
+
+        if ($connections instanceof PDO) {
+            $connections = [self::CONNECTION_DEFAULT_NAME => $connections];
+        }
+
+        $manager = new Manager();
+        foreach ($connections as $name => $connection) {
+            $manager->addConnection([], $name);
+            $manager->getDatabaseManager()
+                ->extend($name, static fn(): Connection => new Connection($connection));
+        }
+
+        return $manager;
+    }
+}

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -21,6 +21,7 @@ final class ReadmeTest extends TestCase implements PhpUnit\MarkdownFileTestInter
             Exception\CouldNotProcessData::class => '',
             Exception\NotImplemented::class => '',
             HasRequirements::class => '',
+            Testing\IlluminateDatabase::class => '',
             PhpUnit\MarkdownFileTestInterface::class => '',
         ];
     }

--- a/tests/Testing/IlluminateDatabaseTest.php
+++ b/tests/Testing/IlluminateDatabaseTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\Shorts\Testing;
+
+use Illuminate\Database\Capsule\Manager;
+use Illuminate\Database\Eloquent\Model;
+use PDO;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\TestCase;
+
+final class IlluminateDatabaseTest extends TestCase
+{
+    public const SQL_TABLE = 'table';
+    private const SQL_CREATE_TABLE = 'CREATE TABLE `' . self::SQL_TABLE . '` (`value` INTEGER)';
+    private const SQL_INSERT_INTO = 'INSERT INTO `' . self::SQL_TABLE . '` (`value`) VALUES (?)';
+
+    private array $pdos;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $pdo1 = new PDO('sqlite::memory:');
+        $pdo1->exec(self::SQL_CREATE_TABLE);
+        $pdo1->prepare(self::SQL_INSERT_INTO)->execute([1]);
+
+        $pdo2 = new PDO('sqlite::memory:');
+        $pdo2->exec(self::SQL_CREATE_TABLE);
+        $pdo2->prepare(self::SQL_INSERT_INTO)->execute([2]);
+
+        $this->pdos = [
+            'pdo1' => $pdo1,
+            'pdo2' => $pdo2,
+        ];
+    }
+
+    public function testCreatesCapsuleManager(): Manager
+    {
+        $capsuleManager = IlluminateDatabase::createCapsuleManager($this->pdos);
+
+        self::assertInstanceOf(Manager::class, $capsuleManager);
+        foreach ($this->pdos as $name => $pdo) {
+            self::assertSame($pdo, $capsuleManager->getConnection($name)->getPdo());
+        }
+
+        return $capsuleManager;
+    }
+
+    #[Depends('testCreatesCapsuleManager')]
+    public function testCreatedCapsuleManagerWorksWithEloquent(Manager $manager): void
+    {
+        $manager->bootEloquent();
+
+        self::assertSame(
+            [
+                'pdo1' => [1],
+                'pdo2' => [2],
+            ],
+            [
+                'pdo1' => self::createModel('pdo1')->newQuery()->pluck('value')->all(),
+                'pdo2' => self::createModel('pdo2')->newQuery()->pluck('value')->all(),
+            ]
+        );
+    }
+
+    private static function createModel(string $connection): Model
+    {
+        $model = new class () extends Model {
+            protected $table = IlluminateDatabaseTest::SQL_TABLE;
+            public $timestamps = false;
+        };
+        $model->setConnection($connection);
+        return $model;
+    }
+}


### PR DESCRIPTION
- [x] This pull request does not contain any breaking change.
- [x] I asked [the AI](https://copilot.microsoft.com/) to briefly summarize, use and improve the feature(s), and I'm okay with the output:

>> Could you briefly summarize the following code for me?
>> ```php
>> namespace Testing;
>> 
>> use Illuminate\Database\Capsule\Manager;
>> use Illuminate\Database\Eloquent\Model;
>> use PDO;
>> 
>> final class IlluminateDatabase
>> {
>>     /**
>>      * @param PDO|array<string, PDO> $pdos well-known PDOs keyed by connection names
>>      *
>>      * @return Manager
>>      *
>>      * @see Manager::setAsGlobal() if you want to use {@see Manager} globally
>>      * @see Manager::bootEloquent() if you want to use {@see Model}s
>>      */
>>     public static function createCapsuleManager(PDO|array $pdos): object
>>     {
>>         // ...
>>     }
>> }
>> ```
>
> This PHP class defines a small utility for setting up an **Illuminate Database Capsule Manager** (the standalone version of Laravel’s database layer).
> - The class `IlluminateDatabase` contains a single static method: `createCapsuleManager(PDO|array $pdos)`
> - The method accepts either:
>   - a single PDO instance, or
>   - an array of PDO instances keyed by connection name.
> - It returns an instance of `Illuminate\Database\Capsule\Manager`, which can then be:
>   - made global via `Manager::setAsGlobal()`
>   - used with Eloquent models via `Manager::bootEloquent()`
>
> Essentially, this is a helper for bootstrapping Eloquent outside of a full Laravel application.
>
>> Could you show me how to use it?
> 
> ```php
> use Testing\IlluminateDatabase;
> use Illuminate\Database\Eloquent\Model;
> 
> // 1. Create a PDO connection (or several)
> $pdo = new PDO('mysql:host=localhost;dbname=test', 'root', 'secret');
> 
> // 2. Build the Capsule manager using your helper
> $capsule = IlluminateDatabase::createCapsuleManager($pdo);
> 
> // 3. (Optional) Make it globally available
> $capsule->setAsGlobal();
> 
> // 4. (Optional) Boot Eloquent ORM
> $capsule->bootEloquent();
> 
> // 5. Define a model and start using Eloquent
> class User extends Model
> {
>     protected $table = 'users';
>     public $timestamps = false;
> }
> 
> // 6. Use Eloquent normally
> $users = User::all();
> 
> foreach ($users as $user) {
>     echo $user->name . PHP_EOL;
> }
> ```
>
>> Is there any way to do `Testing\IlluminateDatabase` better?
> 
> **Support both PDOs and config arrays**, if you want maximum flexibility, you can accept either:
> - a PDO instance
> - an array of PDOs
> - an array of config arrays
> - a mix of both
>
> **Provide sensible defaults**, you can make the helper more “Laravel‑like” by automatically:
> - calling `setAsGlobal()`
> - calling `bootEloquent()`
>
> Unless the user opts out. Example
> ```php
> public static function createCapsuleManager(
>     PDO|array $pdos,
>     bool $global = true,
>     bool $bootEloquent = true
> ): Manager
> ```
> 
> **Add tests**, a helper like this is easy to test:
> - create an in‑memory SQLite PDO
> - build the capsule
> - assert that `Manager::connection()` returns the same PDO
> - assert that Eloquent boots correctly
